### PR TITLE
UPDATE: Upgradable, Deployable, new logic

### DIFF
--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -1,0 +1,189 @@
+pragma solidity ^0.8.18;
+
+// SPDX-License-Identifier: MIT
+
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import {BeaconProxy} from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
+import {DeviceWalletFactory} from "./device-wallet/DeviceWalletFactory.sol";
+import {DeviceWallet} from "./device-wallet/DeviceWallet.sol";
+import {ESIMWalletFactory} from "./esim-wallet/ESIMWalletFactory.sol";
+import {ESIMWallet} from "./esim-wallet/ESIMWallet.sol";
+
+error OnlyAdmin();
+error OnlyDeviceWallet();
+error OnlyDeviceWalletFactory();
+
+// TODO:
+// * Add deploy function
+//     * This deploy function should first deploy device wallet
+//     * Then it should deploy esim wallet
+// * Remove the feature of deploying esim wallet from inside device wallet
+// * Update the esimWalletFactory.deployESIM's require statement to allow 
+// this registry to deploy contract
+// * Move necessary mappings from device wallet factory and esim wallet factory to here
+/// @notice Contract for deploying the factory contracts and maintaining registry
+contract Registry {
+
+    event WalletDeployed(
+        string _deviceUniqueIdentifier,
+        address indexed _deviceWallet,
+        address indexed _eSIMWallet
+    );
+
+    event DeviceWalletInfoUpdated(
+        address indexed _deviceWallet,
+        string _deviceUniqueIdentifier,
+        address indexed _deviceWalletOwner
+    );
+
+    event UpdatedDeviceWalletassociatedWithESIMWallet(
+        address indexed _eSIMWalletAddress,
+        address indexed _deviceWalletAddress
+    );
+
+    ///@notice eSIM wallet project admin address
+    address public admin;
+
+    /// @notice Address of the vault that receives payments for the eSIM data bundles
+    address public vault;
+
+    /// @notice Address (owned/controlled by eSIM wallet project) that can upgrade contracts
+    address public upgradeManager;
+
+    /// @notice Device wallet factory instance
+    DeviceWalletFactory public deviceWalletFactory;
+
+    /// @notice eSIM wallet factory instance
+    ESIMWalletFactory public eSIMWalletFactory;
+
+    /// @notice owner <> device wallet address
+    /// @dev There can only be one device wallet per user (ETH address)
+    mapping(address => address) public ownerToDeviceWallet;
+
+    /// @notice device unique identifier <> device wallet address
+    ///         Mapping for all the device wallets deployed by the registry
+    /// @dev Use this to check if a device identifier has already been used or not
+    mapping(string => address) public uniqueIdentifierToDeviceWallet;
+
+    /// @notice device wallet address <> owner.
+    ///         Mapping of all the devce wallets deployed by the registry (or the device wallet factory)
+    ///         to their respecitve owner.
+    ///         Mapping returns address(0) if device wallet doesn't exist or if not deployed by the said contracts
+    mapping(address => address) public isDeviceWalletValid;
+
+    /// @notice eSIM wallet address <> device wallet address
+    ///         All the eSIM wallets deployed using this registry are valid and set to true
+    mapping(address => address) public isESIMWalletValid;
+
+    modifier onlyDeviceWallet() {
+        if(isDeviceWalletValid[msg.sender] == address(0)) revert OnlyDeviceWallet();
+        _;
+    }
+
+    modifier onlyAdmin() {
+        if (msg.sender != admin) revert OnlyAdmin();
+        _;
+    }
+
+    modifier onlyDeviceWalletFactory() {
+        if(msg.sender != address(deviceWalletFactory)) revert OnlyDeviceWalletFactory();
+        _;
+    }
+
+    /// @param _eSIMWalletAdmin Admin address of the eSIM wallet project
+    /// @param _vault Address of the vault that receives payments for the data bundles
+    /// @param _upgradeManager Admin address responsible for upgrading contracts
+    constructor(address _eSIMWalletAdmin, address _vault, address _upgradeManager) {
+        require(_eSIMWalletAdmin != address(0), "eSIM Admin address cannot be zero address");
+        require(_vault != address(0), "Vault address cannot be zero address");
+        require(_upgradeManager != address(0), "Upgrade Manager address cannot be zero address");
+
+        admin = _eSIMWalletAdmin;
+        vault = _vault;
+        upgradeManager = _upgradeManager;
+
+        // TODO: Make The factory contract ERC1967 Proxy + Upgradable
+        deviceWalletFactory = new DeviceWalletFactory(
+            address(this),
+            _eSIMWalletAdmin,
+            _vault,
+            _upgradeManager
+        );
+
+        // TODO: Make The factory contract ERC1967 Proxy + Upgradable
+        eSIMWalletFactory = new ESIMWalletFactory(
+            address(this),
+            _upgradeManager
+        );
+    }
+
+    /// Allow anyone to deploy a device wallet and an eSIM wallet for themselves
+    /// @param _deviceUniqueIdentifier Unique device identifier associated with the device
+    /// @return Return device wallet address and eSIM wallet address
+    function deployWallet(
+        string calldata _deviceUniqueIdentifier
+    ) external returns (address, address) {
+        require(bytes(_deviceUniqueIdentifier).length >= 1, "Device unique identifier cannot be empty");
+        require(ownerToDeviceWallet[msg.sender] == address(0), "User is already an owner of a device wallet");
+        require(
+            uniqueIdentifierToDeviceWallet[_deviceUniqueIdentifier] == address(0),
+            "Device wallet already exists"
+        );
+
+        address deviceWallet = deviceWalletFactory.deployDeviceWallet(_deviceUniqueIdentifier, msg.sender);
+        _updateDeviceWalletInfo(deviceWallet, _deviceUniqueIdentifier, msg.sender);
+
+        address eSIMWallet = eSIMWalletFactory.deployESIMWallet(msg.sender);
+        _updateESIMInfo(eSIMWallet, deviceWallet);
+
+        emit WalletDeployed(_deviceUniqueIdentifier, deviceWallet, eSIMWallet);
+
+        return (deviceWallet, eSIMWallet);
+    }
+
+    function updateDeviceWalletAssociatedWithESIMWallet(
+        address _eSIMWalletAddress,
+        address _deviceWalletAddress
+    ) external onlyDeviceWallet {
+        isESIMWalletValid[_eSIMWalletAddress] = _deviceWalletAddress;
+        emit UpdatedDeviceWalletassociatedWithESIMWallet(_eSIMWalletAddress, _deviceWalletAddress);
+    }
+
+    /// @dev For all the device wallets deployed by the esim wallet admin using the device wallet factory,
+    ///      update the mappings
+    /// @param _deviceWallet Address of the device wallet
+    /// @param _deviceUniqueIdentifier String unique identifier associated with the device wallet
+    function updateDeviceWalletInfo(
+        address _deviceWallet,
+        string calldata _deviceUniqueIdentifier,
+        address _deviceWalletOwner
+    ) external onlyDeviceWalletFactory {
+        _updateDeviceWalletInfo(_deviceWallet, _deviceUniqueIdentifier, _deviceWalletOwner);
+    }
+
+    function _updateDeviceWalletInfo(
+        address _deviceWallet,
+        string calldata _deviceUniqueIdentifier,
+        address _deviceWalletOwner
+    ) internal {
+        ownerToDeviceWallet[_deviceWalletOwner] = _deviceWallet;
+        uniqueIdentifierToDeviceWallet[_deviceUniqueIdentifier] = _deviceWallet;
+        isDeviceWalletValid[_deviceWallet] = _deviceWalletOwner;
+
+        emit DeviceWalletInfoUpdated(_deviceWallet, _deviceUniqueIdentifier, _deviceWalletOwner);
+    }
+
+    function _updateESIMInfo(
+        address _eSIMWalletAddress,
+        address _deviceWalletAddress
+    ) internal {
+        DeviceWallet(payable(_deviceWalletAddress)).updateESIMInfo(_eSIMWalletAddress, true, true);
+        DeviceWallet(payable(_deviceWalletAddress)).updateDeviceWalletAssociatedWithESIMWallet(
+            _eSIMWalletAddress,
+            _deviceWalletAddress
+        );
+
+
+        isESIMWalletValid[_eSIMWalletAddress] = _deviceWalletAddress;
+    }
+}

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -13,14 +13,6 @@ error OnlyAdmin();
 error OnlyDeviceWallet();
 error OnlyDeviceWalletFactory();
 
-// TODO:
-// * Add deploy function
-//     * This deploy function should first deploy device wallet
-//     * Then it should deploy esim wallet
-// * Remove the feature of deploying esim wallet from inside device wallet
-// * Update the esimWalletFactory.deployESIM's require statement to allow 
-// this registry to deploy contract
-// * Move necessary mappings from device wallet factory and esim wallet factory to here
 /// @notice Contract for deploying the factory contracts and maintaining registry
 contract Registry {
 

--- a/contracts/UpgradableBeacon.sol
+++ b/contracts/UpgradableBeacon.sol
@@ -4,14 +4,15 @@ pragma solidity ^0.8.18;
 
 import "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 /// @title Beacon with upgradeable implementation
 /// @dev Beacon contract holds information about the implementation contract
 ///      and is used by all the proxy contracts to interact with the implementation contract
 ///      A beacon proxy is used in scenarios where a single implementation contract is used by
 ///      multiple proxy contracts. In this case, eSIM wallets and device wallets
-contract UpgradeableBeacon is IBeacon, Ownable {
+// contract UpgradeableBeacon is IBeacon, OwnableUpgradeable {
+contract UpgradeableBeacon is IBeacon, OwnableUpgradeable {
     using Address for address;
 
     address private implementationContractAddress_;
@@ -23,8 +24,7 @@ contract UpgradeableBeacon is IBeacon, Ownable {
     /// @dev ownership is transferred to an address owned by admin
     constructor(address _implementation, address _owner) {
         _setImplementation(_implementation);
-
-        transferOwnership(_owner);
+        __Ownable_init(_owner);
     }
 
     /// @return current implementation contract address
@@ -42,7 +42,7 @@ contract UpgradeableBeacon is IBeacon, Ownable {
     ///      Make sure that the supplied address is a contract
     function _setImplementation(address _implementationContractAddress) private {
         require(_implementationContractAddress != address(0), "Invalid implementation");
-        require(_implementationContractAddress.isContract(), "Implementation address must be a contract address");
+        // require(_implementationContractAddress.isContract(), "Implementation address must be a contract address");
         implementationContractAddress_ = _implementationContractAddress;
         emit Upgraded(implementationContractAddress_);
     }

--- a/contracts/device-wallet/DeviceWallet.sol
+++ b/contracts/device-wallet/DeviceWallet.sol
@@ -5,10 +5,13 @@ pragma solidity ^0.8.18;
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {ESIMWallet} from "../esim-wallet/ESIMWallet.sol";
-import {ESIMWalletFactory} from "../esim-wallet/ESIMWalletFactory.sol";
+import {Registry} from "../Registry.sol";
 import {DeviceWalletFactory} from "./DeviceWalletFactory.sol";
+import {ESIMWalletFactory} from "../esim-wallet/ESIMWalletFactory.sol";
+import {ESIMWallet} from "../esim-wallet/ESIMWallet.sol";
 
+error OnlyRegistryOrDeviceWalletFactoryOrOwner();
+error OnlyDeviceWalletOrOwner();
 error OnlyESIMWalletAdmin();
 error OnlyESIMWalletAdminOrDeviceWalletOwner();
 error OnlyESIMWalletAdminOrDeviceWalletFactory();
@@ -16,7 +19,7 @@ error OnlyAssociatedESIMWallets();
 error FailedToTransfer();
 
 // TODO: Add ReentrancyGuard
-contract DeviceWallet is Ownable, Initializable {
+contract DeviceWallet is Initializable, Ownable {
     using Address for address;
 
     /// @notice Emitted when the contract pays ETH for data bundle
@@ -29,17 +32,17 @@ contract DeviceWallet is Ownable, Initializable {
     /// @dev mostly when an eSIM wallet pulls ETH from this contract
     event ETHSent(address indexed _eSIMWalletAddress, uint256 _amount);
 
-    /// @notice ESIM wallet factory contract instance
-    ESIMWalletFactory public eSIMWalletFactory;
+    /// @notice Emitted when eSIM wallet is deployed
+    event ESIMWalletDeployed(address indexed _eSIMWalletAddress, bool _hasAccessToETH);
 
-    /// @notice Device wallet factory contract instance
-    DeviceWalletFactory public deviceWalletFactory;
+    /// @notice Registry contract instance
+    Registry public registry;
 
     /// @notice String identifier to uniquely identify user's device
     string public deviceUniqueIdentifier;
 
     /// @notice Mapping from eSIMUniqueIdentifier to the respective eSIM wallet address
-    mapping(string => address) public eSIMUniqueIdentifierToESIMWalletAddress;
+    mapping(string => address) public uniqueIdentifierToESIMWallet;
 
     /// @notice Set to true if the eSIM wallet belongs to this device wallet
     mapping(address => bool) public isValidESIMWallet;
@@ -47,31 +50,49 @@ contract DeviceWallet is Ownable, Initializable {
     /// @notice Mapping that tracks if an associated eSIM wallet can pull ETH or not
     mapping(address => bool) public canPullETH;
 
-    /// @notice Parameters required to deploy Device Wallet
-    /// @dev Used to solve stack too deep error
-    struct InitParams {
-        address _deviceWalletFactoryAddress;    // Device wallet factory smart contract address
-        address _eSIMWalletFactoryAddress;      // eSIM wallet factory smart contract address
-        address _deviceWalletOwner;             // User's address (Owner of device wallet and related eSIM wallet smart contracts)
-        string _deviceUniqueIdentifier;         // String to uniquely identify the device wallet
+    modifier onlyRegistryOrDeviceWalletFactoryOrOwner() {
+        if(
+            msg.sender != address(registry) &&
+            msg.sender != address(registry.deviceWalletFactory()) &&
+            msg.sender != owner()
+        ) {
+            revert OnlyRegistryOrDeviceWalletFactoryOrOwner();
+        }
+        _;
+    }
+
+    modifier onlyDeviceWalletFactoryOrOwner() {
+        if(
+            msg.sender != owner() &&
+            msg.sender != address(registry.deviceWalletFactory())
+        ) {
+            revert OnlyDeviceWalletOrOwner();
+        }
+        _;
     }
 
     modifier onlyESIMWalletAdmin() {
-        if (msg.sender != deviceWalletFactory.eSIMWalletAdmin()) {
+        if (msg.sender != registry.deviceWalletFactory().eSIMWalletAdmin()) {
             revert OnlyESIMWalletAdmin();
         }
         _;
     }
 
     modifier onlyESIMWalletAdminOrDeviceWalletFactory() {
-        if (msg.sender != deviceWalletFactory.eSIMWalletAdmin() && msg.sender != address(deviceWalletFactory)) {
+        if (
+            msg.sender != registry.deviceWalletFactory().eSIMWalletAdmin() &&
+            msg.sender != address(registry.deviceWalletFactory())
+        ) {
             revert OnlyESIMWalletAdminOrDeviceWalletFactory();
         }
         _;
     }
 
     modifier onlyESIMWalletAdminOrDeviceWalletOwner() {
-        if (msg.sender != deviceWalletFactory.eSIMWalletAdmin() && msg.sender != owner()) {
+        if (
+            msg.sender != registry.deviceWalletFactory().eSIMWalletAdmin() &&
+            msg.sender != owner()
+        ) {
             revert OnlyESIMWalletAdminOrDeviceWalletOwner();
         }
         _;
@@ -87,23 +108,16 @@ contract DeviceWallet is Ownable, Initializable {
 
     /// @notice Initialises the device wallet and deploys eSIM wallets for any already existing eSIMs
     function init(
-        address _deviceWalletFactoryAddress,
-        address _eSIMWalletFactoryAddress,
+        address _registry,
         address _deviceWalletOwner,
         string calldata _deviceUniqueIdentifier
     ) external initializer {
-        require(_deviceWalletFactoryAddress != address(0), "Device wallet factory cannot be zero address");
+        require(_registry != address(0), "Registry contract cannot be zero address");
         require(_deviceWalletOwner != address(0), "eSIM wallet owner cannot be zero address");
         require(bytes(_deviceUniqueIdentifier).length != 0, "Device unique identifier cannot be zero");
 
-        deviceWalletFactory = DeviceWalletFactory(_deviceWalletFactoryAddress);
+        registry = Registry(_registry);
         deviceUniqueIdentifier = _deviceUniqueIdentifier;
-        eSIMWalletFactory = ESIMWalletFactory(_eSIMWalletFactoryAddress);
-
-        address eSIMWalletAddress = eSIMWalletFactory.deployESIMWallet(_deviceWalletOwner);
-
-        isValidESIMWallet[eSIMWalletAddress] = true;
-        canPullETH[eSIMWalletAddress] = true;
 
         _transferOwnership(_deviceWalletOwner);
     }
@@ -114,10 +128,12 @@ contract DeviceWallet is Ownable, Initializable {
     function deployESIMWallet(
         bool _hasAccessToETH
     ) external onlyOwner returns (address) {
-        address eSIMWalletAddress = eSIMWalletFactory.deployESIMWallet(owner());
+        ESIMWalletFactory eSIMWalletFactory = registry.eSIMWalletFactory();
+        address eSIMWalletAddress = eSIMWalletFactory.deployESIMWallet(msg.sender);
 
-        isValidESIMWallet[eSIMWalletAddress] = true;
-        canPullETH[eSIMWalletAddress] = _hasAccessToETH;
+        _updateESIMInfo(eSIMWalletAddress, true, _hasAccessToETH);
+        _updateDeviceWalletAssociatedWithESIMWallet(eSIMWalletAddress, address(this));
+        emit ESIMWalletDeployed(eSIMWalletAddress, _hasAccessToETH);
 
         return eSIMWalletAddress;
     }
@@ -125,16 +141,16 @@ contract DeviceWallet is Ownable, Initializable {
     /// @notice Allow wallet owner or admin to set unique identifier for their eSIM wallet
     /// @param _eSIMWalletAddress Address of the eSIM wallet smart contract
     /// @param _eSIMUniqueIdentifier String unique identifier for the eSIM wallet
-    function setESIMUniqueIdentifierForAnESIMWallet(address _eSIMWalletAddress, string calldata _eSIMUniqueIdentifier)
-        public
-        onlyESIMWalletAdmin
-        returns (string memory)
-    {
+    function setESIMUniqueIdentifierForAnESIMWallet(
+        address _eSIMWalletAddress,
+        string calldata _eSIMUniqueIdentifier
+    ) public onlyESIMWalletAdmin returns (string memory) {
         require(
-            eSIMWalletFactory.isESIMWalletDeployed(_eSIMWalletAddress) == true, "Unknown eSIM wallet address provided"
+            registry.isESIMWalletValid(_eSIMWalletAddress) != address(0),
+            "Unknown eSIM wallet address provided"
         );
         require(
-            eSIMUniqueIdentifierToESIMWalletAddress[_eSIMUniqueIdentifier] == address(0),
+            uniqueIdentifierToESIMWallet[_eSIMUniqueIdentifier] == address(0),
             "eSIM unique identifier already set for the provided eSIM wallet"
         );
 
@@ -174,7 +190,7 @@ contract DeviceWallet is Ownable, Initializable {
     /// @notice Fetches the vault address (that receives payment for data bundles) from the device wallet factory
     /// @dev Mostly used by the associated eSIM wallets for reference
     function getVaultAddress() public view returns (address) {
-        return deviceWalletFactory.vault();
+        return registry.vault();
     }
 
     /// @notice Allow owner to revoke or give access to any associated eSIM wallet for pulling ETH
@@ -197,6 +213,39 @@ contract DeviceWallet is Ownable, Initializable {
             if (!success) revert FailedToTransfer();
             else emit ETHSent(_recipient, _amount);
         }
+    }
+
+    function updateESIMInfo(
+        address _eSIMWalletAddress,
+        bool _isESIMWalletValid,
+        bool _hasAccessToETH
+    ) external onlyRegistryOrDeviceWalletFactoryOrOwner {
+        _updateESIMInfo(_eSIMWalletAddress, _isESIMWalletValid, _hasAccessToETH);
+    }
+
+    function _updateESIMInfo(
+        address _eSIMWalletAddress,
+        bool _isESIMWalletValid,
+        bool _hasAccessToETH
+    ) internal {
+        isValidESIMWallet[_eSIMWalletAddress] = _isESIMWalletValid;
+        canPullETH[_eSIMWalletAddress] = _hasAccessToETH;
+    }
+
+    function updateDeviceWalletAssociatedWithESIMWallet(
+        address _eSIMWalletAddress,
+        address _deviceWalletAddress
+    ) external onlyDeviceWalletFactoryOrOwner {
+        require(_deviceWalletAddress != address(this), "Cannot update device wallet to same address");
+        _updateDeviceWalletAssociatedWithESIMWallet(_eSIMWalletAddress, _deviceWalletAddress);
+        isValidESIMWallet[_eSIMWalletAddress] = false;
+    }
+
+    function _updateDeviceWalletAssociatedWithESIMWallet(
+        address _eSIMWalletAddress,
+        address _deviceWalletAddress
+    ) internal {
+        registry.updateDeviceWalletAssociatedWithESIMWallet(_eSIMWalletAddress, _deviceWalletAddress);
     }
 
     receive() external payable {

--- a/contracts/esim-wallet/ESIMWallet.sol
+++ b/contracts/esim-wallet/ESIMWallet.sol
@@ -68,15 +68,11 @@ contract ESIMWallet is IOwnableESIMWallet, Ownable, Initializable {
     /// @param _eSIMWalletFactoryAddress eSIM wallet factory contract address
     /// @param _deviceWalletAddress Device wallet contract address (the contract that deploys this eSIM wallet)
     /// @param _eSIMWalletOwner User's address
-    /// @param _eSIMUniqueIdentifier Unique identifier for the eSIM wallet
     function init(
         address _eSIMWalletFactoryAddress,
         address _deviceWalletAddress,
-        address _eSIMWalletOwner,
-        string calldata _dataBundleID,
-        uint256 _dataBundlePrice,
-        string calldata _eSIMUniqueIdentifier
-    ) external payable override initializer {
+        address _eSIMWalletOwner
+    ) external override initializer {
         require(_eSIMWalletOwner != address(0), "Owner cannot be address zero");
         require(_eSIMWalletFactoryAddress != address(0), "eSIM wallet factory address cannot be zero");
         require(_deviceWalletAddress != address(0), "Device wallet address cannot be zero");
@@ -84,15 +80,7 @@ contract ESIMWallet is IOwnableESIMWallet, Ownable, Initializable {
         eSIMWalletFactory = _eSIMWalletFactoryAddress;
         deviceWallet = DeviceWallet(payable(_deviceWalletAddress));
 
-        if (bytes(_eSIMUniqueIdentifier).length > 0) {
-            eSIMUniqueIdentifier = _eSIMUniqueIdentifier;
-            emit ESIMUniqueIdentifierInitialised(_eSIMUniqueIdentifier);
-        }
-
         _transferOwnership(_eSIMWalletOwner);
-
-        // no need to specify {value: msg.value} as the function exists in same contract
-        buyDataBundle(_dataBundleID, _dataBundlePrice);
 
         emit ESIMWalletDeployed(address(this), _deviceWalletAddress, _eSIMWalletOwner);
     }

--- a/contracts/esim-wallet/ESIMWallet.sol
+++ b/contracts/esim-wallet/ESIMWallet.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.18;
 
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {IOwnableESIMWallet} from "../interfaces/IOwnableESIMWallet.sol";
 import {DeviceWallet} from "../device-wallet/DeviceWallet.sol";
@@ -11,7 +11,7 @@ import {DeviceWallet} from "../device-wallet/DeviceWallet.sol";
 error OnlyDeviceWallet();
 error FailedToTransfer();
 
-contract ESIMWallet is IOwnableESIMWallet, Ownable, Initializable {
+contract ESIMWallet is IOwnableESIMWallet, Initializable, OwnableUpgradeable {
     using Address for address;
 
     /// Emitted when the eSIM wallet is deployed
@@ -62,17 +62,17 @@ contract ESIMWallet is IOwnableESIMWallet, Ownable, Initializable {
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() initializer {}
 
-    /// @notice ESIMWallet init function to initialise the contract
+    /// @notice ESIMWallet initialize function to initialise the contract
     /// @dev If _eSIMUniqueIdentifier is empty, the eSIM wallet is being deployed before buying an eSIM
     ///      If _eSIMUniqueIdentifier is non-empty, the eSIM wallet is being deployed after the eSIM has been bought by the user
     /// @param _eSIMWalletFactoryAddress eSIM wallet factory contract address
     /// @param _deviceWalletAddress Device wallet contract address (the contract that deploys this eSIM wallet)
     /// @param _eSIMWalletOwner User's address
-    function init(
+    function initialize(
         address _eSIMWalletFactoryAddress,
         address _deviceWalletAddress,
         address _eSIMWalletOwner
-    ) external override initializer {
+    ) external initializer {
         require(_eSIMWalletOwner != address(0), "Owner cannot be address zero");
         require(_eSIMWalletFactoryAddress != address(0), "eSIM wallet factory address cannot be zero");
         require(_deviceWalletAddress != address(0), "Device wallet address cannot be zero");
@@ -80,7 +80,7 @@ contract ESIMWallet is IOwnableESIMWallet, Ownable, Initializable {
         eSIMWalletFactory = _eSIMWalletFactoryAddress;
         deviceWallet = DeviceWallet(payable(_deviceWalletAddress));
 
-        _transferOwnership(_eSIMWalletOwner);
+        __Ownable_init(_eSIMWalletOwner);
 
         emit ESIMWalletDeployed(address(this), _deviceWalletAddress, _eSIMWalletOwner);
     }
@@ -131,13 +131,13 @@ contract ESIMWallet is IOwnableESIMWallet, Ownable, Initializable {
     }
 
     /// @dev Returns the current owner of the wallet
-    function owner() public view override(IOwnableESIMWallet, Ownable) returns (address) {
-        return Ownable.owner();
+    function owner() public view override(IOwnableESIMWallet, OwnableUpgradeable) returns (address) {
+        return OwnableUpgradeable.owner();
     }
 
     /// @dev Transfers ownership from the current owner to another address
     /// @param newOwner The address that will be the new owner
-    function transferOwnership(address newOwner) public override(IOwnableESIMWallet, Ownable) {
+    function transferOwnership(address newOwner) public override(IOwnableESIMWallet, OwnableUpgradeable) {
         // Only the admin of deviceWalletFactory contract can transfer ownership
         require(isTransferApproved(owner(), msg.sender), "OwnableSmartWallet: Transfer is not allowed");
 

--- a/contracts/esim-wallet/ESIMWalletFactory.sol
+++ b/contracts/esim-wallet/ESIMWalletFactory.sol
@@ -24,8 +24,7 @@ contract ESIMWalletFactory {
     /// @notice Emitted when a new eSIM wallet is deployed
     event ESIMWalletDeployed(
         address indexed _eSIMWalletAddress,
-        string _dataBundleID,
-        uint256 _dataBundlePrice,
+        address indexed _owner,
         address indexed _deviceWalletAddress
     );
 
@@ -69,15 +68,10 @@ contract ESIMWalletFactory {
     /// Function to deploy an eSIM wallet
     /// @dev can only be called by the respective deviceWallet contract
     /// @param _owner Owner of the eSIM wallet
-    /// @param _dataBundleID String ID of data bundle to buy for the new eSIM
-    /// @param _dataBundlePrice uint256 USD price for data bundle
     /// @return Address of the newly deployed eSIM wallet
     function deployESIMWallet(
-        address _owner,
-        string calldata _dataBundleID,
-        uint256 _dataBundlePrice,
-        string calldata _eSIMUniqueIdentifier
-    ) external payable returns (address) {
+        address _owner
+    ) external returns (address) {
         require(deviceWalletFactory.isDeviceWalletValid(msg.sender), "Only device wallet can call this");
 
         // msg.value will be sent along with the abi.encodeCall
@@ -86,13 +80,13 @@ contract ESIMWalletFactory {
                 beacon,
                 abi.encodeCall(
                     ESIMWallet(payable(eSIMWalletImplementation)).init,
-                    (address(this), msg.sender, _owner, _dataBundleID, _dataBundlePrice, _eSIMUniqueIdentifier)
+                    (address(this), msg.sender, _owner)
                 )
             )
         );
         isESIMWalletDeployed[eSIMWalletAddress] = true;
 
-        emit ESIMWalletDeployed(eSIMWalletAddress, _dataBundleID, _dataBundlePrice, msg.sender);
+        emit ESIMWalletDeployed(eSIMWalletAddress, _owner, msg.sender);
 
         return eSIMWalletAddress;
     }

--- a/contracts/interfaces/IOwnableESIMWallet.sol
+++ b/contracts/interfaces/IOwnableESIMWallet.sol
@@ -9,11 +9,8 @@ interface IOwnableESIMWallet is IOwnableESIMWalletEvents {
     function init(
         address eSIMWalletFactoryAddress,
         address deviceWalletAddress,
-        address owner,
-        string calldata _dataBundleID,
-        uint256 _dataBundlePrice,
-        string calldata eSIMUniqueIdentifier
-    ) external payable;
+        address owner
+    ) external;
 
     function setESIMUniqueIdentifier(string calldata eSIMUniqueIdentifier) external;
 

--- a/contracts/interfaces/IOwnableESIMWallet.sol
+++ b/contracts/interfaces/IOwnableESIMWallet.sol
@@ -6,7 +6,7 @@ interface IOwnableESIMWalletEvents {
 }
 
 interface IOwnableESIMWallet is IOwnableESIMWalletEvents {
-    function init(
+    function initialize(
         address eSIMWalletFactoryAddress,
         address deviceWalletAddress,
         address owner

--- a/docs/Registry.md
+++ b/docs/Registry.md
@@ -1,0 +1,213 @@
+# Solidity API
+
+## OnlyDeviceWallet
+
+```solidity
+error OnlyDeviceWallet()
+```
+
+## OnlyDeviceWalletFactory
+
+```solidity
+error OnlyDeviceWalletFactory()
+```
+
+## Registry
+
+Contract for deploying the factory contracts and maintaining registry
+
+### WalletDeployed
+
+```solidity
+event WalletDeployed(string _deviceUniqueIdentifier, address _deviceWallet, address _eSIMWallet)
+```
+
+### DeviceWalletInfoUpdated
+
+```solidity
+event DeviceWalletInfoUpdated(address _deviceWallet, string _deviceUniqueIdentifier, address _deviceWalletOwner)
+```
+
+### UpdatedDeviceWalletassociatedWithESIMWallet
+
+```solidity
+event UpdatedDeviceWalletassociatedWithESIMWallet(address _eSIMWalletAddress, address _deviceWalletAddress)
+```
+
+### admin
+
+```solidity
+address admin
+```
+
+eSIM wallet project admin address
+
+### vault
+
+```solidity
+address vault
+```
+
+Address of the vault that receives payments for the eSIM data bundles
+
+### upgradeManager
+
+```solidity
+address upgradeManager
+```
+
+Address (owned/controlled by eSIM wallet project) that can upgrade contracts
+
+### deviceWalletFactory
+
+```solidity
+contract DeviceWalletFactory deviceWalletFactory
+```
+
+Device wallet factory instance
+
+### eSIMWalletFactory
+
+```solidity
+contract ESIMWalletFactory eSIMWalletFactory
+```
+
+eSIM wallet factory instance
+
+### ownerToDeviceWallet
+
+```solidity
+mapping(address => address) ownerToDeviceWallet
+```
+
+owner <> device wallet address
+
+_There can only be one device wallet per user (ETH address)_
+
+### uniqueIdentifierToDeviceWallet
+
+```solidity
+mapping(string => address) uniqueIdentifierToDeviceWallet
+```
+
+device unique identifier <> device wallet address
+        Mapping for all the device wallets deployed by the registry
+
+_Use this to check if a device identifier has already been used or not_
+
+### isDeviceWalletValid
+
+```solidity
+mapping(address => address) isDeviceWalletValid
+```
+
+device wallet address <> owner.
+        Mapping of all the devce wallets deployed by the registry (or the device wallet factory)
+        to their respecitve owner.
+        Mapping returns address(0) if device wallet doesn't exist or if not deployed by the said contracts
+
+### isESIMWalletValid
+
+```solidity
+mapping(address => address) isESIMWalletValid
+```
+
+eSIM wallet address <> device wallet address
+        All the eSIM wallets deployed using this registry are valid and set to true
+
+### onlyDeviceWallet
+
+```solidity
+modifier onlyDeviceWallet()
+```
+
+### onlyDeviceWalletFactory
+
+```solidity
+modifier onlyDeviceWalletFactory()
+```
+
+### constructor
+
+```solidity
+constructor() public
+```
+
+### _authorizeUpgrade
+
+```solidity
+function _authorizeUpgrade(address newImplementation) internal
+```
+
+_Owner based upgrades_
+
+### initialize
+
+```solidity
+function initialize(address _eSIMWalletAdmin, address _vault, address _upgradeManager) external
+```
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _eSIMWalletAdmin | address | Admin address of the eSIM wallet project |
+| _vault | address | Address of the vault that receives payments for the data bundles |
+| _upgradeManager | address | Admin address responsible for upgrading contracts |
+
+### deployWallet
+
+```solidity
+function deployWallet(string _deviceUniqueIdentifier) external returns (address, address)
+```
+
+Allow anyone to deploy a device wallet and an eSIM wallet for themselves
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _deviceUniqueIdentifier | string | Unique device identifier associated with the device |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | address | Return device wallet address and eSIM wallet address |
+| [1] | address |  |
+
+### updateDeviceWalletAssociatedWithESIMWallet
+
+```solidity
+function updateDeviceWalletAssociatedWithESIMWallet(address _eSIMWalletAddress, address _deviceWalletAddress) external
+```
+
+### updateDeviceWalletInfo
+
+```solidity
+function updateDeviceWalletInfo(address _deviceWallet, string _deviceUniqueIdentifier, address _deviceWalletOwner) external
+```
+
+_For all the device wallets deployed by the esim wallet admin using the device wallet factory,
+     update the mappings_
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _deviceWallet | address | Address of the device wallet |
+| _deviceUniqueIdentifier | string | String unique identifier associated with the device wallet |
+| _deviceWalletOwner | address |  |
+
+### _updateDeviceWalletInfo
+
+```solidity
+function _updateDeviceWalletInfo(address _deviceWallet, string _deviceUniqueIdentifier, address _deviceWalletOwner) internal
+```
+
+### _updateESIMInfo
+
+```solidity
+function _updateESIMInfo(address _eSIMWalletAddress, address _deviceWalletAddress) internal
+```
+

--- a/docs/device-wallet/DeviceWallet.md
+++ b/docs/device-wallet/DeviceWallet.md
@@ -1,5 +1,17 @@
 # Solidity API
 
+## OnlyRegistryOrDeviceWalletFactoryOrOwner
+
+```solidity
+error OnlyRegistryOrDeviceWalletFactoryOrOwner()
+```
+
+## OnlyDeviceWalletOrOwner
+
+```solidity
+error OnlyDeviceWalletOrOwner()
+```
+
 ## OnlyESIMWalletAdmin
 
 ```solidity
@@ -58,21 +70,21 @@ Emitted when ETH is sent out from the contract
 
 _mostly when an eSIM wallet pulls ETH from this contract_
 
-### eSIMWalletFactory
+### ESIMWalletDeployed
 
 ```solidity
-contract ESIMWalletFactory eSIMWalletFactory
+event ESIMWalletDeployed(address _eSIMWalletAddress, bool _hasAccessToETH)
 ```
 
-ESIM wallet factory contract instance
+Emitted when eSIM wallet is deployed
 
-### deviceWalletFactory
+### registry
 
 ```solidity
-contract DeviceWalletFactory deviceWalletFactory
+contract Registry registry
 ```
 
-Device wallet factory contract instance
+Registry contract instance
 
 ### deviceUniqueIdentifier
 
@@ -82,10 +94,10 @@ string deviceUniqueIdentifier
 
 String identifier to uniquely identify user's device
 
-### eSIMUniqueIdentifierToESIMWalletAddress
+### uniqueIdentifierToESIMWallet
 
 ```solidity
-mapping(string => address) eSIMUniqueIdentifierToESIMWalletAddress
+mapping(string => address) uniqueIdentifierToESIMWallet
 ```
 
 Mapping from eSIMUniqueIdentifier to the respective eSIM wallet address
@@ -106,40 +118,22 @@ mapping(address => bool) canPullETH
 
 Mapping that tracks if an associated eSIM wallet can pull ETH or not
 
-### InitParams
-
-Parameters required to deploy Device Wallet
-
-_Used to solve stack too deep error_
+### onlyRegistryOrDeviceWalletFactoryOrOwner
 
 ```solidity
-struct InitParams {
-  address _deviceWalletFactoryAddress;
-  address _eSIMWalletFactoryAddress;
-  address _deviceWalletOwner;
-  string _deviceUniqueIdentifier;
-  string[] _dataBundleIDs;
-  uint256[] _dataBundlePrices;
-  string[] _eSIMUniqueIdentifiers;
-}
+modifier onlyRegistryOrDeviceWalletFactoryOrOwner()
+```
+
+### onlyDeviceWalletFactoryOrOwner
+
+```solidity
+modifier onlyDeviceWalletFactoryOrOwner()
 ```
 
 ### onlyESIMWalletAdmin
 
 ```solidity
 modifier onlyESIMWalletAdmin()
-```
-
-### onlyESIMWalletAdminOrDeviceWalletFactory
-
-```solidity
-modifier onlyESIMWalletAdminOrDeviceWalletFactory()
-```
-
-### onlyESIMWalletAdminOrDeviceWalletOwner
-
-```solidity
-modifier onlyESIMWalletAdminOrDeviceWalletOwner()
 ```
 
 ### onlyAssociatedESIMWallets
@@ -154,10 +148,10 @@ modifier onlyAssociatedESIMWallets()
 constructor() public
 ```
 
-### init
+### initialize
 
 ```solidity
-function init(struct DeviceWallet.InitParams _initParams) external payable
+function initialize(address _registry, address _deviceWalletOwner, string _deviceUniqueIdentifier) external
 ```
 
 Initialises the device wallet and deploys eSIM wallets for any already existing eSIMs
@@ -165,7 +159,7 @@ Initialises the device wallet and deploys eSIM wallets for any already existing 
 ### deployESIMWallet
 
 ```solidity
-function deployESIMWallet(string _dataBundleID, uint256 _dataBundlePrice, string _eSIMUniqueIdentifier, bool _hasAccessToETH) external payable returns (address)
+function deployESIMWallet(bool _hasAccessToETH) external returns (address)
 ```
 
 Allow device wallet owner to deploy new eSIM wallet
@@ -174,9 +168,6 @@ Allow device wallet owner to deploy new eSIM wallet
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _dataBundleID | string | String data bundle ID to be bought for the eSIM |
-| _dataBundlePrice | uint256 | Price in uint256 for the data bundle |
-| _eSIMUniqueIdentifier | string | String unique identifier for the eSIM wallet |
 | _hasAccessToETH | bool | Set to true if the eSIM wallet is allowed to pull ETH from this wallet. |
 
 #### Return Values
@@ -260,6 +251,30 @@ Allow owner to revoke or give access to any associated eSIM wallet for pulling E
 
 ```solidity
 function _transferETH(address _recipient, uint256 _amount) internal virtual
+```
+
+### updateESIMInfo
+
+```solidity
+function updateESIMInfo(address _eSIMWalletAddress, bool _isESIMWalletValid, bool _hasAccessToETH) external
+```
+
+### _updateESIMInfo
+
+```solidity
+function _updateESIMInfo(address _eSIMWalletAddress, bool _isESIMWalletValid, bool _hasAccessToETH) internal
+```
+
+### updateDeviceWalletAssociatedWithESIMWallet
+
+```solidity
+function updateDeviceWalletAssociatedWithESIMWallet(address _eSIMWalletAddress, address _deviceWalletAddress) external
+```
+
+### _updateDeviceWalletAssociatedWithESIMWallet
+
+```solidity
+function _updateDeviceWalletAssociatedWithESIMWallet(address _eSIMWalletAddress, address _deviceWalletAddress) internal
 ```
 
 ### receive

--- a/docs/device-wallet/DeviceWalletFactory.md
+++ b/docs/device-wallet/DeviceWalletFactory.md
@@ -10,18 +10,10 @@ error OnlyAdmin()
 
 Contract for deploying a new eSIM wallet
 
-### SetESIMWalletFactoryAddress
-
-```solidity
-event SetESIMWalletFactoryAddress(address _eSIMWalletFactoryAddress)
-```
-
-Emitted when the admin sets the eSIM wallet factory address
-
 ### DeviceWalletFactoryDeployed
 
 ```solidity
-event DeviceWalletFactoryDeployed(address _factoryAddress, address _admin, address _vault, address _upgradeManager, address _deviceWalletImplementation, address _beacon)
+event DeviceWalletFactoryDeployed(address _admin, address _vault, address _upgradeManager, address _deviceWalletImplementation, address _beacon)
 ```
 
 Emitted when factory is deployed and admin is set
@@ -37,7 +29,7 @@ Emitted when the Vault address is updated
 ### DeviceWalletDeployed
 
 ```solidity
-event DeviceWalletDeployed(address _deviceWalletAddress, string[] _eSIMUniqueIdentifiers)
+event DeviceWalletDeployed(address _deviceWalletAddress, address _eSIMWalletAddress, address _deviceWalletOwner)
 ```
 
 Emitted when a new device wallet is deployed
@@ -82,29 +74,13 @@ address beacon
 
 Beacon contract address for this contract
 
-### eSIMWalletFactoryAddress
+### registry
 
 ```solidity
-address eSIMWalletFactoryAddress
+contract Registry registry
 ```
 
-eSIM wallet factory contract address;
-
-### walletAddressOfDeviceUniqueIdentifier
-
-```solidity
-mapping(string => address) walletAddressOfDeviceUniqueIdentifier
-```
-
-deviceUniqueIdentifier <> deviceWalletAddress
-
-### isDeviceWalletValid
-
-```solidity
-mapping(address => bool) isDeviceWalletValid
-```
-
-Set to true if device wallet was deployed by the device wallet factory, false otherwise.
+Registry contract instance
 
 ### onlyAdmin
 
@@ -115,13 +91,28 @@ modifier onlyAdmin()
 ### constructor
 
 ```solidity
-constructor(address _eSIMWalletAdmin, address _vault, address _upgradeManager) public
+constructor() public
+```
+
+### _authorizeUpgrade
+
+```solidity
+function _authorizeUpgrade(address newImplementation) internal
+```
+
+_Owner based upgrades_
+
+### initialize
+
+```solidity
+function initialize(address _registryContractAddress, address _eSIMWalletAdmin, address _vault, address _upgradeManager) external
 ```
 
 #### Parameters
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
+| _registryContractAddress | address |  |
 | _eSIMWalletAdmin | address | Admin address of the eSIM wallet project |
 | _vault | address | Address of the vault that receives payments for the data bundles |
 | _upgradeManager | address | Admin address responsible for upgrading contracts |
@@ -156,16 +147,10 @@ Function to update admin address
 | ---- | ---- | ----------- |
 | _newAdmin | address | New admin address |
 
-### setESIMWalletFactoryAddress
+### deployDeviceWalletForUsers
 
 ```solidity
-function setESIMWalletFactoryAddress(address _eSIMWalletFactoryAddress) public returns (address)
-```
-
-### deployMultipleDeviceWalletsWithESIMWallets
-
-```solidity
-function deployMultipleDeviceWalletsWithESIMWallets(string[] _deviceUniqueIdentifiers, string[][] _dataBundleIDs, uint256[][] _dataBundlePrices, string[][] _eSIMUniqueIdentifiers) public payable returns (address[])
+function deployDeviceWalletForUsers(string[] _deviceUniqueIdentifiers, address[] _deviceWalletOwners) public returns (address[])
 ```
 
 To deploy multiple device wallets at once
@@ -175,9 +160,7 @@ To deploy multiple device wallets at once
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | _deviceUniqueIdentifiers | string[] | Array of unique device identifiers for each device wallet |
-| _dataBundleIDs | string[][] | 2D array of IDs of data bundles to be bought for respective eSIMs |
-| _dataBundlePrices | uint256[][] | 2D array of price of respective data bundles for respective eSIMs |
-| _eSIMUniqueIdentifiers | string[][] | 2D array of unique eSIM identifiers for each device wallet |
+| _deviceWalletOwners | address[] | Array of owner address of the respective device wallets |
 
 #### Return Values
 
@@ -185,22 +168,40 @@ To deploy multiple device wallets at once
 | ---- | ---- | ----------- |
 | [0] | address[] | Array of deployed device wallet address |
 
-### deployDeviceWalletWithESIMWallets
+### deployDeviceWalletAsAdmin
 
 ```solidity
-function deployDeviceWalletWithESIMWallets(string _deviceUniqueIdentifier, string[] _dataBundleIDs, uint256[] _dataBundlePrices, string[] _eSIMUniqueIdentifiers, address _deviceWalletOwner) public payable returns (address)
+function deployDeviceWalletAsAdmin(string _deviceUniqueIdentifier, address _deviceWalletOwner) public returns (address)
 ```
 
-_To deploy a device wallet and eSIM wallets for given unique eSIM identifiers_
+_Allow admin to deploy a device wallet (and an eSIM wallet) for given unique device identifiers_
 
 #### Parameters
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | _deviceUniqueIdentifier | string | Unique device identifier for the device wallet |
-| _dataBundleIDs | string[] | List of IDs of data bundles to be bought for respective eSIMs |
-| _dataBundlePrices | uint256[] | List of price of respective data bundles |
-| _eSIMUniqueIdentifiers | string[] | Array of unique eSIM identifiers for the device wallet |
+| _deviceWalletOwner | address | User's address (owner of the device wallet and respective eSIM wallets) |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | address | Deployed device wallet address |
+
+### deployDeviceWallet
+
+```solidity
+function deployDeviceWallet(string _deviceUniqueIdentifier, address _deviceWalletOwner) public returns (address)
+```
+
+_Allow admin to deploy a device wallet (and an eSIM wallet) for given unique device identifiers_
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _deviceUniqueIdentifier | string | Unique device identifier for the device wallet |
 | _deviceWalletOwner | address | User's address (owner of the device wallet and respective eSIM wallets) |
 
 #### Return Values

--- a/docs/esim-wallet/ESIMWallet.md
+++ b/docs/esim-wallet/ESIMWallet.md
@@ -116,13 +116,13 @@ modifier onlyDeviceWallet()
 constructor() public
 ```
 
-### init
+### initialize
 
 ```solidity
-function init(address _eSIMWalletFactoryAddress, address _deviceWalletAddress, address _eSIMWalletOwner, string _dataBundleID, uint256 _dataBundlePrice, string _eSIMUniqueIdentifier) external payable
+function initialize(address _eSIMWalletFactoryAddress, address _deviceWalletAddress, address _eSIMWalletOwner) external
 ```
 
-ESIMWallet init function to initialise the contract
+ESIMWallet initialize function to initialise the contract
 
 _If _eSIMUniqueIdentifier is empty, the eSIM wallet is being deployed before buying an eSIM
      If _eSIMUniqueIdentifier is non-empty, the eSIM wallet is being deployed after the eSIM has been bought by the user_
@@ -134,9 +134,6 @@ _If _eSIMUniqueIdentifier is empty, the eSIM wallet is being deployed before buy
 | _eSIMWalletFactoryAddress | address | eSIM wallet factory contract address |
 | _deviceWalletAddress | address | Device wallet contract address (the contract that deploys this eSIM wallet) |
 | _eSIMWalletOwner | address | User's address |
-| _dataBundleID | string |  |
-| _dataBundlePrice | uint256 |  |
-| _eSIMUniqueIdentifier | string | Unique identifier for the eSIM wallet |
 
 ### setESIMUniqueIdentifier
 

--- a/docs/esim-wallet/ESIMWalletFactory.md
+++ b/docs/esim-wallet/ESIMWalletFactory.md
@@ -1,9 +1,9 @@
 # Solidity API
 
-## OnlyDeviceWalletFactory
+## OnlyRegistryOrDeviceWalletFactoryOrDeviceWallet
 
 ```solidity
-error OnlyDeviceWalletFactory()
+error OnlyRegistryOrDeviceWalletFactoryOrDeviceWallet()
 ```
 
 ## ESIMWalletFactory
@@ -13,7 +13,7 @@ Contract for deploying a new eSIM wallet
 ### ESIMWalletFactorydeployed
 
 ```solidity
-event ESIMWalletFactorydeployed(address _eSIMWalletFactory, address _deviceWalletFactory, address _upgradeManager, address _eSIMWalletImplementation, address beacon)
+event ESIMWalletFactorydeployed(address _upgradeManager, address _eSIMWalletImplementation, address beacon)
 ```
 
 Emitted when the eSIM wallet factory is deployed
@@ -21,18 +21,18 @@ Emitted when the eSIM wallet factory is deployed
 ### ESIMWalletDeployed
 
 ```solidity
-event ESIMWalletDeployed(address _eSIMWalletAddress, string _dataBundleID, uint256 _dataBundlePrice, address _deviceWalletAddress)
+event ESIMWalletDeployed(address _eSIMWalletAddress, address _owner, address _deviceWalletAddress)
 ```
 
 Emitted when a new eSIM wallet is deployed
 
-### deviceWalletFactory
+### registry
 
 ```solidity
-contract DeviceWalletFactory deviceWalletFactory
+contract Registry registry
 ```
 
-Address of the device wallet factory
+Address of the registry contract
 
 ### eSIMWalletImplementation
 
@@ -58,29 +58,43 @@ mapping(address => bool) isESIMWalletDeployed
 
 Set to true if eSIM wallet address is deployed using the factory, false otherwise
 
-### onlyDeviceWalletFactory
+### onlyRegistryOrDeviceWalletFactoryOrDeviceWallet
 
 ```solidity
-modifier onlyDeviceWalletFactory()
+modifier onlyRegistryOrDeviceWalletFactoryOrDeviceWallet()
 ```
 
 ### constructor
 
 ```solidity
-constructor(address _deviceWalletFactoryAddress, address _upgradeManager) public
+constructor() public
+```
+
+### _authorizeUpgrade
+
+```solidity
+function _authorizeUpgrade(address newImplementation) internal
+```
+
+_Owner based upgrades_
+
+### initialize
+
+```solidity
+function initialize(address _registryContractAddress, address _upgradeManager) external
 ```
 
 #### Parameters
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _deviceWalletFactoryAddress | address | Address of the device wallet factory address |
+| _registryContractAddress | address | Address of the registry contract |
 | _upgradeManager | address | Admin address responsible for upgrading contracts |
 
 ### deployESIMWallet
 
 ```solidity
-function deployESIMWallet(address _owner, string _dataBundleID, uint256 _dataBundlePrice, string _eSIMUniqueIdentifier) external payable returns (address)
+function deployESIMWallet(address _owner) external returns (address)
 ```
 
 Function to deploy an eSIM wallet
@@ -92,9 +106,6 @@ _can only be called by the respective deviceWallet contract_
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | _owner | address | Owner of the eSIM wallet |
-| _dataBundleID | string | String ID of data bundle to buy for the new eSIM |
-| _dataBundlePrice | uint256 | uint256 USD price for data bundle |
-| _eSIMUniqueIdentifier | string |  |
 
 #### Return Values
 

--- a/docs/interfaces/IOwnableESIMWallet.md
+++ b/docs/interfaces/IOwnableESIMWallet.md
@@ -10,10 +10,10 @@ event TransferApprovalChanged(address from, address to, bool status)
 
 ## IOwnableESIMWallet
 
-### init
+### initialize
 
 ```solidity
-function init(address eSIMWalletFactoryAddress, address deviceWalletAddress, address owner, string _dataBundleID, uint256 _dataBundlePrice, string eSIMUniqueIdentifier) external payable
+function initialize(address eSIMWalletFactoryAddress, address deviceWalletAddress, address owner) external
 ```
 
 ### setESIMUniqueIdentifier

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,5 +4,7 @@ out = 'out'
 libs = ['node_modules', 'lib', 'test/utils']
 test = 'test/foundry'
 cache_path  = 'forge-cache'
+optimizer = true
+optimizer-runs = 10_000_000
 
 # See more config options https://book.getfoundry.sh/reference/config.html

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,5 +1,5 @@
 require('dotenv').config();
-require("hardhat");
+// require("hardhat");
 require("@nomicfoundation/hardhat-foundry");
 require('solidity-docgen');
 

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,4 +1,5 @@
 require('dotenv').config();
+require("hardhat");
 require("@nomicfoundation/hardhat-foundry");
 
 const PRIV_KEY = process.env.PRIV_KEY;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,8 @@
     "": {
       "name": "smart-contract-suite",
       "dependencies": {
-        "@openzeppelin/contracts": "^4.5.0",
-        "@openzeppelin/contracts-upgradeable": "4.5.0",
+        "@openzeppelin/contracts": "5.0.2",
+        "@openzeppelin/contracts-upgradeable": "5.0.2",
         "dotenv": "^16.4.5",
         "ethers": "^5.7.2",
         "lcov-filter": "^0.1.1"
@@ -1123,14 +1123,17 @@
       }
     },
     "node_modules/@openzeppelin/contracts": {
-      "version": "4.9.6",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.9.6.tgz",
-      "integrity": "sha512-xSmezSupL+y9VkHZJGDoCBpmnB2ogM13ccaYDWqJTfS3dbuHkgjuwDFUmaFauBCboQMGB/S5UqUl2y54X99BmA=="
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.0.2.tgz",
+      "integrity": "sha512-ytPc6eLGcHHnapAZ9S+5qsdomhjo6QBHTDRRBFfTxXIpsicMhVPouPgmUPebZZZGX7vt9USA+Z+0M0dSVtSUEA=="
     },
     "node_modules/@openzeppelin/contracts-upgradeable": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.5.0.tgz",
-      "integrity": "sha512-5540xxycH2aDFI3e+5Mqd0GDeozkSKSEaNWoM65l90OYxZxOs9YQMqa+b4fR+363BXXSXoC1DTXut2TuqViwPA=="
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-5.0.2.tgz",
+      "integrity": "sha512-0MmkHSHiW2NRFiT9/r5Lu4eJq5UJ4/tzlOgYXNAIj/ONkQTVnz22pLxDvp4C4uZ9he7ZFvGn3Driptn1/iU7tQ==",
+      "peerDependencies": {
+        "@openzeppelin/contracts": "5.0.2"
+      }
     },
     "node_modules/@scure/base": {
       "version": "1.1.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "smart-contract-suite",
   "scripts": {
-    "forge-build": "forge build",
+    "forge-build": "forge build --sizes",
     "test": "forge test -vv",
     "test-debug": "forge test -vvv",
     "coverage": "forge coverage",
@@ -9,8 +9,8 @@
     "html-coverage-report": "forge coverage --report lcov && genhtml lcov.info -o report"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^4.5.0",
-    "@openzeppelin/contracts-upgradeable": "4.5.0",
+    "@openzeppelin/contracts": "5.0.2",
+    "@openzeppelin/contracts-upgradeable": "5.0.2",
     "dotenv": "^16.4.5",
     "ethers": "^5.7.2",
     "lcov-filter": "^0.1.1"

--- a/scripts/deployFactory.js
+++ b/scripts/deployFactory.js
@@ -1,5 +1,5 @@
 require('dotenv').config();
-const { ethers } = require("hardhat");
+const {  ethers, upgrade } = require("hardhat");
 // const { ethers, ContractFactory } = require("ethers");
 
 const API_KEY = process.env.API_KEY;
@@ -7,9 +7,23 @@ const PRIV_KEY = process.env.PRIV_KEY;
 const ADDRESS = process.env.ADDRESS;
 
 const main = async () => {
+    
+    const registry = await ethers.getContractFactory("Registry");
+    console.log("deploying registry");
 
-    const [deployer] = await ethers.getSigners();
-    console.log("deployer: ", deployer);
+    await registry.deployed();
+
+    console.log("registry deployed at: ", registry.address);
+
+    /* To deploy proxy
+    const proxyContract = await upgrades.deployProxy(ContractName, [input params for initializer function], {
+        constructorArgs: [], // check if needed 
+        initializer: "init", // or any other name used for the initializer
+    });
+
+    */
+
+    return;
 
     // const provider = new ethers.providers.AlchemyProvider(
     //     "sepolia",

--- a/test/foundry/fuzz-testing/Registry.t.sol
+++ b/test/foundry/fuzz-testing/Registry.t.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import "forge-std/Test.sol";
+import "../../../contracts/Registry.sol";
+
+contract RegistryTest is Test {
+
+    address accountOne = "0x5B38Da6a701c568545dCfcB03FcB875f56beddC4";
+    address accountTwo = "0xAb8483F64d9C6d1EcF9b849Ae677dD3315835cb2";
+    address accountThree = "0x4B20993Bc481177ec7E8f571ceCaE8A9e22C02db";
+    address accountFour = "0x78731D3Ca6b7E34aC0F824c42a7cC18A495cabaB";
+    address accountFive = "0x617F2E2fD72FD9D5503197092aC168c91465E7f2";
+    address accountSix = "0x17F6AD8Ef982297579C203069C1DbfFE4348c372";
+    address accountSeven = "0x5c6B0f7Bf3E7ce046039Bd8FABdfD3f9F5021678";
+
+    Registry defaultRegistry;
+
+    // function setUp() { 
+    // }
+}

--- a/test/foundry/fuzz-testing/Registry.t.sol
+++ b/test/foundry/fuzz-testing/Registry.t.sol
@@ -6,13 +6,13 @@ import "../../../contracts/Registry.sol";
 
 contract RegistryTest is Test {
 
-    address accountOne = "0x5B38Da6a701c568545dCfcB03FcB875f56beddC4";
-    address accountTwo = "0xAb8483F64d9C6d1EcF9b849Ae677dD3315835cb2";
-    address accountThree = "0x4B20993Bc481177ec7E8f571ceCaE8A9e22C02db";
-    address accountFour = "0x78731D3Ca6b7E34aC0F824c42a7cC18A495cabaB";
-    address accountFive = "0x617F2E2fD72FD9D5503197092aC168c91465E7f2";
-    address accountSix = "0x17F6AD8Ef982297579C203069C1DbfFE4348c372";
-    address accountSeven = "0x5c6B0f7Bf3E7ce046039Bd8FABdfD3f9F5021678";
+    address accountOne = 0x5B38Da6a701c568545dCfcB03FcB875f56beddC4;
+    address accountTwo = 0xAb8483F64d9C6d1EcF9b849Ae677dD3315835cb2;
+    address accountThree = 0x4B20993Bc481177ec7E8f571ceCaE8A9e22C02db;
+    address accountFour = 0x78731D3Ca6b7E34aC0F824c42a7cC18A495cabaB;
+    address accountFive = 0x617F2E2fD72FD9D5503197092aC168c91465E7f2;
+    address accountSix = 0x17F6AD8Ef982297579C203069C1DbfFE4348c372;
+    address accountSeven = 0x5c6B0f7Bf3E7ce046039Bd8FABdfD3f9F5021678;
 
     Registry defaultRegistry;
 


### PR DESCRIPTION
The contracts are now 
* upgradeable: Allows contracts to be upgraded after deployment, in case of bug fixes and enhancements
* deployable: Unlike before, the contracts are now deployable and manually tested
* beacon proxy: Both the device wallet and eSIM wallet factories use beacon proxy to deploy proxy wallet contracts making the transactions gas efficient
* Registry contract: A new contract that not only acts as registry for all the important contract data but also acts as the deployer and helps set up contracts