### PR TITLE
Implementation for Lazy Wallet

### DIFF
--- a/contracts/CustomStructs.sol
+++ b/contracts/CustomStructs.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.8.18;
+
+// SPDX-License-Identifier: MIT
+
+/// @notice Data Bundle related details stored in the eSIM wallet
+struct DataBundleDetails {
+    string dataBundleID;
+    uint256 dataBundlePrice;
+}
+
+/// @notice Details related to eSIM purchased by the fiat user
+struct ESIMDetails {
+    DataBundleDetails[] history;
+}
+
+/// @notice Struct to store list of all eSIMs associated with a device
+struct AssociatedESIMIdentifiers {
+    string[] eSIMIdentifiers;
+}

--- a/contracts/LazyWalletRegistry.sol
+++ b/contracts/LazyWalletRegistry.sol
@@ -12,6 +12,21 @@ contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeabl
     /// @notice Address (owned/controlled by eSIM wallet project) that can upgrade contracts
     address public upgradeManager;
 
+    /// @notice Data Bundle related details stored in the eSIM wallet
+    struct DataBundleDetail {
+        string dataBundleID;
+        uint256 dataBundlePrice;
+    }
+
+    /// @notice Details related to eSIM purchased by the fiat user
+    struct eSIMDetails {
+        uint256 id;
+        DataBundleDetail[] history;
+    }
+
+    /// @notice Mapping from fiat user's unique device identifier to the eSIM details
+    mapping(string => eSIMDetails[]) public deviceIdentifierToESIMDetails;
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() initializer {
         _disableInitializers();

--- a/contracts/LazyWalletRegistry.sol
+++ b/contracts/LazyWalletRegistry.sol
@@ -135,8 +135,6 @@ contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeabl
 
     /*
         TODO: 
-        * Make changes in device wallet to add history
-        * Make changes in eSIM wallet to add history and other important data
         * Use populate history in the deploy lazy wallet function
         * Look into eSIM state and if possible create 
         an architecture standard for eSIM profile,

--- a/contracts/LazyWalletRegistry.sol
+++ b/contracts/LazyWalletRegistry.sol
@@ -83,6 +83,17 @@ contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeabl
         }
     }
 
+    /*
+        TODO: 
+        * Complete populateHistory function
+        * Update storage variables
+        * Check if device identifier doesn't have existing wallet (using registry)
+        * See if registry can inherit LazyWalletRegistry for deploying wallets
+        * Make changes in device wallet to add history
+        * Make changes in eSIM wallet to add history and other important data
+        * Look into eSIM state and if possible create 
+        an architecture standard for eSIM profile,
+    */
     function _populateHistory(
         string calldata _deviceUniqueIdentifier,
         string[] calldata _eSIMUniqueIdentifiers,

--- a/contracts/LazyWalletRegistry.sol
+++ b/contracts/LazyWalletRegistry.sol
@@ -9,6 +9,9 @@ import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Own
 /// @notice Contract for deploying the factory contracts and maintaining registry
 contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable, RegistryHelper {
 
+    /// @notice Address (owned/controlled by eSIM wallet project) that can upgrade contracts
+    address public upgradeManager;
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() initializer {
         _disableInitializers();
@@ -21,4 +24,10 @@ contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeabl
     override
     {}
 
+    function initialize(address _upgradeManager) external initializer {
+        require(_upgradeManager != address(0), "Upgrade Manager address cannot be zero address");
+        upgradeManager = _upgradeManager;
+
+        __Ownable_init(_upgradeManager);
+    }
 }

--- a/contracts/LazyWalletRegistry.sol
+++ b/contracts/LazyWalletRegistry.sol
@@ -7,13 +7,14 @@ import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/U
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 import {Registry} from "./Registry.sol";
+import "./CustomStructs.sol";
 
 /// @notice Contract for deploying the factory contracts and maintaining registry
 contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable, RegistryHelper {
 
     /// @notice Emitted when data related to a device is updated
     event DataUpdatedForDevice(
-        string _deviceUniqueIdentifier, string[] _eSIMUniqueIdentifiers, DataBundleDetail[] _dataBundleDetails
+        string _deviceUniqueIdentifier, string[] _eSIMUniqueIdentifiers, DataBundleDetails[] _dataBundleDetails
     );
 
     event LazyWalletDeployed(
@@ -29,22 +30,6 @@ contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeabl
 
     /// @notice Registry contract instance
     Registry public registry;
-
-    /// @notice Data Bundle related details stored in the eSIM wallet
-    struct DataBundleDetail {
-        string dataBundleID;
-        uint256 dataBundlePrice;
-    }
-
-    /// @notice Details related to eSIM purchased by the fiat user
-    struct ESIMDetails {
-        DataBundleDetail[] history;
-    }
-
-    /// @notice Struct to store list of all eSIMs associated with a device
-    struct AssociatedESIMIdentifiers {
-        string[] eSIMIdentifiers;
-    }
 
     /// @notice Device identifier <> eSIM identifier <> ESIMDetails(purchase history)
     mapping(string => mapping(string => ESIMDetails)) public deviceIdentifierToESIMDetails;
@@ -104,7 +89,7 @@ contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeabl
     function batchPopulateHistory(
         string[] calldata _deviceUniqueIdentifiers,
         string[][] calldata _eSIMUniqueIdentifiers,
-        DataBundleDetail[][] calldata _dataBundleDetails
+        DataBundleDetails[][] calldata _dataBundleDetails
     ) external {
         uint256 len = _deviceUniqueIdentifiers.length;
         require(len == _eSIMUniqueIdentifiers.length, "Unequal array provided");
@@ -161,7 +146,7 @@ contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeabl
     function _populateHistory(
         string calldata _deviceUniqueIdentifier,
         string[] calldata _eSIMUniqueIdentifiers,
-        DataBundleDetail[] calldata _dataBundleDetails
+        DataBundleDetails[] calldata _dataBundleDetails
     ) internal {
         require(isLazyWalletDeployed(_deviceUniqueIdentifier) == false, "Device identifier is already associated with a device wallet");
         
@@ -181,7 +166,7 @@ contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeabl
             }
 
             ESIMDetails storage eSIMDetails = deviceIdentifierToESIMDetails[_deviceUniqueIdentifier][eSIMUniqueIdentifier];
-            DataBundleDetail[] storage details = eSIMDetails.history;
+            DataBundleDetails[] storage details = eSIMDetails.history;
             details.push(_dataBundleDetails[i]);
             eSIMDetails.history = details;
         }

--- a/contracts/LazyWalletRegistry.sol
+++ b/contracts/LazyWalletRegistry.sol
@@ -6,11 +6,16 @@ import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Ini
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
+import {Registry} from "./Registry.sol";
+
 /// @notice Contract for deploying the factory contracts and maintaining registry
 contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable, RegistryHelper {
 
     /// @notice Address (owned/controlled by eSIM wallet project) that can upgrade contracts
     address public upgradeManager;
+
+    /// @notice Registry contract instance
+    Registry public registry;
 
     /// @notice Data Bundle related details stored in the eSIM wallet
     struct DataBundleDetail {
@@ -20,12 +25,24 @@ contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeabl
 
     /// @notice Details related to eSIM purchased by the fiat user
     struct eSIMDetails {
-        uint256 id;
         DataBundleDetail[] history;
     }
 
-    /// @notice Mapping from fiat user's unique device identifier to the eSIM details
-    mapping(string => eSIMDetails[]) public deviceIdentifierToESIMDetails;
+    /// @notice Struct to store list of all eSIMs associated with a device
+    struct associatedESIMIdentifiers {
+        string[] eSIMIdentifiers;
+    }
+
+    /// @notice Device identifier <> eSIM identifier <> eSIMDetails(purchase history)
+    mapping(string => mapping(string => eSIMDetails)) public deviceIdentifierToESIMDetails;
+
+    /// @notice Mapping from eSIM unique identifier to device unique identifier
+    /// @dev A device identifier can have multiple associated eSIM identifiers.
+    /// But an eSIM identifier can have only a single device identifier.
+    mapping(string => string) public eSIMIdentifierToDeviceIdentifier;
+
+    /// @notice Device identifier <> List of associated eSIM identifiers
+    mapping(string => associatedESIMIdentifiers) public eSIMIdentifiersAssociatedWithDeviceIdentifier;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() initializer {
@@ -39,10 +56,38 @@ contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeabl
     override
     {}
 
-    function initialize(address _upgradeManager) external initializer {
+    function initialize(
+        address _registry,
+        address _upgradeManager
+    ) external initializer {
+        require(_registry != address(0), "Registry contract address cannot be zero");
         require(_upgradeManager != address(0), "Upgrade Manager address cannot be zero address");
+        
+        registry = Registry(_registry);
         upgradeManager = _upgradeManager;
 
         __Ownable_init(_upgradeManager);
+    }
+
+    function batchPopulateHistory(
+        string[] calldata _deviceUniqueIdentifiers,
+        string[][] calldata _eSIMUniqueIdentifiers,
+        eSIMDetails[][] calldata _eSIMDetails
+    ) external {
+        uint256 len = _deviceUniqueIdentifiers.length;
+        require(len == _eSIMUniqueIdentifiers.length, "Unequal array provided");
+        require(len == _eSIMDetails.length, "Unequal array provided");
+
+        for(uint256 i=0; i<len; ++i) {
+            _populateHistory(_deviceUniqueIdentifiers[i], _eSIMUniqueIdentifiers[i], _eSIMDetails[i]);
+        }
+    }
+
+    function _populateHistory(
+        string calldata _deviceUniqueIdentifier,
+        string[] calldata _eSIMUniqueIdentifiers,
+        eSIMDetails[] calldata _eSIMDetails
+    ) internal {
+
     }
 }

--- a/contracts/LazyWalletRegistry.sol
+++ b/contracts/LazyWalletRegistry.sol
@@ -87,6 +87,16 @@ contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeabl
         __Ownable_init(_upgradeManager);
     }
 
+    /// @notice Function to check if a lazy wallet has been deployed or not
+    /// @return Boolean. True if deployed, false otherwise
+    function isLazyWalletDeployed(string calldata _deviceUniqueIdentifier) public returns (bool) {
+        if(registry.uniqueIdentifierToDeviceWallet(_deviceUniqueIdentifier) != address(0)) {
+            return true;
+        }
+
+        return false;
+    }
+
     /// @notice Function to populate all the device and eSIM related data along with the data bundles
     /// @param _deviceUniqueIdentifiers List of device unique identifiers associated with the eSIM related data
     /// @param _eSIMUniqueIdentifiers 2D array of all the eSIMs corresponding to their device identifiers.
@@ -116,6 +126,8 @@ contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeabl
         string calldata _eSIMUniqueIdentifier,
         uint256 _salt
     ) external onlyESIMWalletAdmin returns (address, address) {
+        require(isLazyWalletDeployed(_deviceUniqueIdentifier) == false, "Device identifier is already associated with a device wallet");
+
         address deviceWallet;
         address eSIMWallet;
         (deviceWallet, eSIMWallet) = registry.deployLazyWallet(
@@ -138,7 +150,6 @@ contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeabl
 
     /*
         TODO: 
-        * Once lazy wallet is deployed, update some storage to not accept any new updates in populateHistory function
         * Make changes in device wallet to add history
         * Make changes in eSIM wallet to add history and other important data
         * Use populate history in the deploy lazy wallet function
@@ -152,7 +163,7 @@ contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeabl
         string[] calldata _eSIMUniqueIdentifiers,
         DataBundleDetail[] calldata _dataBundleDetails
     ) internal {
-        require(registry.uniqueIdentifierToDeviceWallet(_deviceUniqueIdentifier) == address(0), "Device identifier is already associated with a device wallet");
+        require(isLazyWalletDeployed(_deviceUniqueIdentifier) == false, "Device identifier is already associated with a device wallet");
         
         uint256 len = _eSIMUniqueIdentifiers.length;
         require(len == _dataBundleDetails.length, "Unequal array provided");

--- a/contracts/LazyWalletRegistry.sol
+++ b/contracts/LazyWalletRegistry.sol
@@ -11,6 +11,11 @@ import {Registry} from "./Registry.sol";
 /// @notice Contract for deploying the factory contracts and maintaining registry
 contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable, RegistryHelper {
 
+    /// @notice Emitted when data related to a device is updated
+    event DataUpdatedForDevice(
+        string _deviceUniqueIdentifier, string[] _eSIMUniqueIdentifiers, DataBundleDetail[] _dataBundleDetails
+    );
+
     /// @notice Address (owned/controlled by eSIM wallet project) that can upgrade contracts
     address public upgradeManager;
 
@@ -24,17 +29,17 @@ contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeabl
     }
 
     /// @notice Details related to eSIM purchased by the fiat user
-    struct eSIMDetails {
+    struct ESIMDetails {
         DataBundleDetail[] history;
     }
 
     /// @notice Struct to store list of all eSIMs associated with a device
-    struct associatedESIMIdentifiers {
+    struct AssociatedESIMIdentifiers {
         string[] eSIMIdentifiers;
     }
 
-    /// @notice Device identifier <> eSIM identifier <> eSIMDetails(purchase history)
-    mapping(string => mapping(string => eSIMDetails)) public deviceIdentifierToESIMDetails;
+    /// @notice Device identifier <> eSIM identifier <> ESIMDetails(purchase history)
+    mapping(string => mapping(string => ESIMDetails)) public deviceIdentifierToESIMDetails;
 
     /// @notice Mapping from eSIM unique identifier to device unique identifier
     /// @dev A device identifier can have multiple associated eSIM identifiers.
@@ -42,7 +47,7 @@ contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeabl
     mapping(string => string) public eSIMIdentifierToDeviceIdentifier;
 
     /// @notice Device identifier <> List of associated eSIM identifiers
-    mapping(string => associatedESIMIdentifiers) public eSIMIdentifiersAssociatedWithDeviceIdentifier;
+    mapping(string => AssociatedESIMIdentifiers) public eSIMIdentifiersAssociatedWithDeviceIdentifier;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() initializer {
@@ -69,17 +74,21 @@ contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeabl
         __Ownable_init(_upgradeManager);
     }
 
+    /// @notice Function to populate all the device and eSIM related data along with the data bundles
+    /// @param _deviceUniqueIdentifiers List of device unique identifiers associated with the eSIM related data
+    /// @param _eSIMUniqueIdentifiers 2D array of all the eSIMs corresponding to their device identifiers.
+    /// @param _dataBundleDetails 2D array of all the new data bundles bought for the respective eSIMs
     function batchPopulateHistory(
         string[] calldata _deviceUniqueIdentifiers,
         string[][] calldata _eSIMUniqueIdentifiers,
-        eSIMDetails[][] calldata _eSIMDetails
+        DataBundleDetail[][] calldata _dataBundleDetails
     ) external {
         uint256 len = _deviceUniqueIdentifiers.length;
         require(len == _eSIMUniqueIdentifiers.length, "Unequal array provided");
-        require(len == _eSIMDetails.length, "Unequal array provided");
+        require(len == _dataBundleDetails.length, "Unequal array provided");
 
         for(uint256 i=0; i<len; ++i) {
-            _populateHistory(_deviceUniqueIdentifiers[i], _eSIMUniqueIdentifiers[i], _eSIMDetails[i]);
+            _populateHistory(_deviceUniqueIdentifiers[i], _eSIMUniqueIdentifiers[i], _dataBundleDetails[i]);
         }
     }
 
@@ -94,11 +103,36 @@ contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeabl
         * Look into eSIM state and if possible create 
         an architecture standard for eSIM profile,
     */
+    /// @notice Internal function for populating information of all the eSIMs related to a device
+    /// @dev The _eSIMUniqueIdentifiers array can have multiple repeating occurrences since there can be multiple purchases per eSIM
     function _populateHistory(
         string calldata _deviceUniqueIdentifier,
         string[] calldata _eSIMUniqueIdentifiers,
-        eSIMDetails[] calldata _eSIMDetails
+        DataBundleDetail[] calldata _dataBundleDetails
     ) internal {
+        require(registry.uniqueIdentifierToDeviceWallet(_deviceUniqueIdentifier) == address(0), "Device identifier is already associated with a device wallet");
+        
+        uint256 len = _eSIMUniqueIdentifiers.length;
+        require(len == _dataBundleDetails.length, "Unequal array provided");
 
+        for(uint256 i=0; i<len; ++i) {
+            string eSIMUniqueIdentifier = _eSIMUniqueIdentifiers[i];
+
+            if(eSIMIdentifierToDeviceIdentifier[eSIMUniqueIdentifier].length == 0) {
+                eSIMIdentifierToDeviceIdentifier[eSIMUniqueIdentifier] = _deviceUniqueIdentifier;
+
+                AssociatedESIMIdentifiers storage associatedESIMIdentifiers = eSIMIdentifiersAssociatedWithDeviceIdentifier[_deviceUniqueIdentifier];
+                string[] storage listOfIdentifiers = associatedESIMIdentifiers.eSIMIdentifiers;
+                listOfIdentifiers.push(eSIMUniqueIdentifier);
+                associatedESIMIdentifiers.eSIMIdentifiers = listOfIdentifiers;
+            }
+
+            ESIMDetails storage eSIMDetails = deviceIdentifierToESIMDetails[_deviceUniqueIdentifier][eSIMUniqueIdentifier];
+            DataBundleDetail[] storage details = eSIMDetails.history;
+            details.push(_dataBundleDetails[i]);
+            eSIMDetails.history = details;
+        }
+
+        emit DataUpdatedForDevice(_deviceUniqueIdentifier, _eSIMUniqueIdentifiers, _dataBundleDetails);
     }
 }

--- a/contracts/LazyWalletRegistry.sol
+++ b/contracts/LazyWalletRegistry.sol
@@ -94,6 +94,7 @@ contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeabl
 
     /*
         TODO: 
+        * Use deployLazyWallet function from RegistryHelper in this contract
         * Make changes in device wallet to add history
         * Make changes in eSIM wallet to add history and other important data
         * Look into eSIM state and if possible create 

--- a/contracts/LazyWalletRegistry.sol
+++ b/contracts/LazyWalletRegistry.sol
@@ -94,9 +94,6 @@ contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeabl
 
     /*
         TODO: 
-        * Complete populateHistory function
-        * Update storage variables
-        * Check if device identifier doesn't have existing wallet (using registry)
         * See if registry can inherit LazyWalletRegistry for deploying wallets
         * Make changes in device wallet to add history
         * Make changes in eSIM wallet to add history and other important data

--- a/contracts/LazyWalletRegistry.sol
+++ b/contracts/LazyWalletRegistry.sol
@@ -94,7 +94,6 @@ contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeabl
 
     /*
         TODO: 
-        * See if registry can inherit LazyWalletRegistry for deploying wallets
         * Make changes in device wallet to add history
         * Make changes in eSIM wallet to add history and other important data
         * Look into eSIM state and if possible create 

--- a/contracts/LazyWalletRegistry.sol
+++ b/contracts/LazyWalletRegistry.sol
@@ -1,0 +1,24 @@
+pragma solidity ^0.8.18;
+
+// SPDX-License-Identifier: MIT
+
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
+/// @notice Contract for deploying the factory contracts and maintaining registry
+contract LazyWalletRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable, RegistryHelper {
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() initializer {
+        _disableInitializers();
+    }
+
+    /// @dev Owner based upgrades
+    function _authorizeUpgrade(address newImplementation)
+    internal
+    onlyOwner
+    override
+    {}
+
+}

--- a/contracts/RegistryHelper.sol
+++ b/contracts/RegistryHelper.sol
@@ -30,7 +30,7 @@ contract RegistryHelper {
     );
 
     /// @notice Address of the Lazy wallet registry
-    adress public lazyWalletRegistry;
+    address public lazyWalletRegistry;
 
     /// @notice owner <> device wallet address
     /// @dev There can only be one device wallet per user (ETH address)

--- a/contracts/RegistryHelper.sol
+++ b/contracts/RegistryHelper.sol
@@ -74,6 +74,7 @@ contract RegistryHelper {
     function deployLazyWallet(
         address _deviceOwner,
         string calldata _deviceUniqueIdentifier,
+        string calldata _eSIMUniqueIdentifier,
         uint256 _salt
     ) external onlyLazyWalletRegistry returns (address, address) {
         require(bytes(_deviceUniqueIdentifier).length >= 1, "Device unique identifier cannot be empty");

--- a/contracts/RegistryHelper.sol
+++ b/contracts/RegistryHelper.sol
@@ -92,6 +92,10 @@ contract RegistryHelper {
 
         emit WalletDeployed(_deviceUniqueIdentifier, deviceWallet, eSIMWallet);
 
+        // Since the eSIM unique identifier is already known in this scenario
+        // We can execute the setESIMUniqueIdentifierForAnESIMWallet function in same transaction as deploying the smart wallet
+        DeviceWallet(deviceWallet).setESIMUniqueIdentifierForAnESIMWallet(eSIMWallet, _eSIMUniqueIdentifier);
+
         return (deviceWallet, eSIMWallet);
     }
 

--- a/contracts/RegistryHelper.sol
+++ b/contracts/RegistryHelper.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.18;
 // SPDX-License-Identifier: MIT
 
 import {DeviceWallet} from "./device-wallet/DeviceWallet.sol";
+import {ESIMWallet} from "./esim-wallet/ESIMWallet.sol";
+import "./CustomStructs.sol";
 
 error OnlyLazyWalletRegistry();
 
@@ -75,7 +77,8 @@ contract RegistryHelper {
         address _deviceOwner,
         string calldata _deviceUniqueIdentifier,
         string calldata _eSIMUniqueIdentifier,
-        uint256 _salt
+        uint256 _salt,
+        DataBundleDetails[] memory _dataBundleDetails
     ) external onlyLazyWalletRegistry returns (address, address) {
         require(bytes(_deviceUniqueIdentifier).length >= 1, "Device unique identifier cannot be empty");
         require(bytes(_eSIMUniqueIdentifier).length >= 1, "eSIM unique identifier cannot be empty");
@@ -96,6 +99,9 @@ contract RegistryHelper {
         // Since the eSIM unique identifier is already known in this scenario
         // We can execute the setESIMUniqueIdentifierForAnESIMWallet function in same transaction as deploying the smart wallet
         DeviceWallet(deviceWallet).setESIMUniqueIdentifierForAnESIMWallet(eSIMWallet, _eSIMUniqueIdentifier);
+
+        // Populate data bundle purchase details for the eSIM wallet
+        ESIMWallet(eSIMWallet).populateHistory(_dataBundleDetails);
 
         return (deviceWallet, eSIMWallet);
     }

--- a/contracts/RegistryHelper.sol
+++ b/contracts/RegistryHelper.sol
@@ -67,7 +67,7 @@ contract RegistryHelper {
         emit UpdatedLazyWalletRegistryAddress(_lazyWalletRegistry);
     }
 
-    /// Allow LazyWalletRegistry  to deploy a device wallet and an eSIM wallet on behalf of a user
+    /// @notice Allow LazyWalletRegistry to deploy a device wallet and an eSIM wallet on behalf of a user
     /// @param _deviceOwner Address of the device owner
     /// @param _deviceUniqueIdentifier Unique device identifier associated with the device
     /// @return Return device wallet address and eSIM wallet address
@@ -78,6 +78,7 @@ contract RegistryHelper {
         uint256 _salt
     ) external onlyLazyWalletRegistry returns (address, address) {
         require(bytes(_deviceUniqueIdentifier).length >= 1, "Device unique identifier cannot be empty");
+        require(bytes(_eSIMUniqueIdentifier).length >= 1, "eSIM unique identifier cannot be empty");
         require(ownerToDeviceWallet[_deviceOwner] == address(0), "User is already an owner of a device wallet");
         require(
             uniqueIdentifierToDeviceWallet[_deviceUniqueIdentifier] == address(0),

--- a/contracts/aa-helper/Account4337.sol
+++ b/contracts/aa-helper/Account4337.sol
@@ -11,8 +11,10 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@account-abstraction/contracts/core/BaseAccount.sol";
 import "@account-abstraction/contracts/core/Helpers.sol";
 import "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+// To allow the smart wallet to handle ERC20 and ERC721 tokens
+import {TokenCallbackHandler} from "@account-abstraction/contracts/samples/callback/TokenCallbackHandler.sol";
 
-contract Account4337 is BaseAccount, Initializable, UUPSUpgradeable {
+contract Account4337 is BaseAccount, Initializable, UUPSUpgradeable, TokenCallbackHandler {
     using MessageHashUtils for bytes32;
     using ECDSA for bytes32;
 

--- a/contracts/esim-wallet/ESIMWallet.sol
+++ b/contracts/esim-wallet/ESIMWallet.sol
@@ -7,6 +7,7 @@ import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Ini
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {IOwnableESIMWallet} from "../interfaces/IOwnableESIMWallet.sol";
 import {DeviceWallet} from "../device-wallet/DeviceWallet.sol";
+import "../CustomStructs.sol";
 
 error OnlyDeviceWallet();
 error FailedToTransfer();
@@ -41,11 +42,6 @@ contract ESIMWallet is IOwnableESIMWallet, Initializable, OwnableUpgradeable {
 
     /// @notice Total number of data bundle transactions made by user
     uint256 public lastTransactionCount;
-
-    struct DataBundleDetails {
-        string dataBundleID;
-        uint256 dataBundlePrice;
-    }
 
     /// @notice lastTransactionCount -> (data bundle ID, data bundle price)
     mapping(uint256 => DataBundleDetails) public transactionHistory;


### PR DESCRIPTION
A significant number of Koki'o users will be new to crypto and they will probably use fiat for buying data bundles and eSIM. 
For such users, it will rather be better if the wallets are not deployed in the beginning, and this will not only save gas from not deploying the wallet but also save gas from not updating the data bundle payment history in the wallets.
With the Lazy wallet registry, all the data-bundle purchase history (for the fiat users) can be synced on-chain periodically and as a single batch transaction. This will save a lot of gas from the unwanted wallet deployments and maintenance.
Later on, when the fiat user is actually ready to use their device wallet, the Lazy Wallet Registry can be used to deploy the necessary wallets and populate them with previous purchase history.
As of now, the data being populated is the purchase history, but this might change and more data might be saved on-chain.