### PR TITLE
Refactoring code

### DIFF
--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -120,4 +120,17 @@ contract Registry is Initializable, UUPSUpgradeable, OwnableUpgradeable, Registr
     ) external onlyDeviceWalletFactory {
         _updateDeviceWalletInfo(_deviceWallet, _deviceUniqueIdentifier, _deviceWalletOwnerKey);
     }
+
+    /// @notice Update eSIM standby status when being moved from one device wallet to another
+    /// @param _eSIMWalletAddress Address of the eSIM wallet
+    /// @param _isOnStandby Set to true when no device wallet is associated, false otherwise
+    function setESIMWalletToStandby(
+        address _eSIMWalletAddress,
+        bool _isOnStandby
+    ) public onlyDeviceWallet {
+        require(isESIMWalletValid[_eSIMWalletAddress] == msg.sender, "Unauthorised caller");
+
+        isESIMWalletOnStandby[_eSIMWalletAddress] = _isOnStandby;
+        emit ESIMWalletSetOnStandby(_eSIMWalletAddress, _isOnStandby, msg.sender);
+    }
 }

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -101,30 +101,6 @@ contract Registry is Initializable, UUPSUpgradeable, OwnableUpgradeable, Registr
         return lazyWalletRegistry;
     }
 
-    /// Allow anyone to deploy a device wallet and an eSIM wallet for themselves
-    /// @param _deviceUniqueIdentifier Unique device identifier associated with the device
-    /// @return Return device wallet address and eSIM wallet address
-    function deployWallet(
-        string calldata _deviceUniqueIdentifier,
-        bytes32[2] memory _deviceWalletOwnerKey,
-        uint256 _salt
-    ) external returns (address, address) {
-        require(bytes(_deviceUniqueIdentifier).length >= 1, "Device identifier 0");
-        require(
-            uniqueIdentifierToDeviceWallet[_deviceUniqueIdentifier] == address(0),
-            "Device wallet already exists"
-        );
-
-        address deviceWallet = deviceWalletFactory.deployDeviceWallet(_deviceUniqueIdentifier, _deviceWalletOwnerKey, _salt);
-
-        address eSIMWallet = eSIMWalletFactory.deployESIMWallet(deviceWallet, _salt);
-        _updateESIMInfo(eSIMWallet, deviceWallet);
-
-        emit WalletDeployed(_deviceUniqueIdentifier, deviceWallet, eSIMWallet);
-
-        return (deviceWallet, eSIMWallet);
-    }
-
     function updateDeviceWalletAssociatedWithESIMWallet(
         address _eSIMWalletAddress,
         address _deviceWalletAddress

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -124,7 +124,7 @@ contract Registry is Initializable, UUPSUpgradeable, OwnableUpgradeable, Registr
     /// @notice Update eSIM standby status when being moved from one device wallet to another
     /// @param _eSIMWalletAddress Address of the eSIM wallet
     /// @param _isOnStandby Set to true when no device wallet is associated, false otherwise
-    function setESIMWalletToStandby(
+    function toggleESIMWalletStandbyStatus(
         address _eSIMWalletAddress,
         bool _isOnStandby
     ) public onlyDeviceWallet {

--- a/contracts/RegistryHelper.sol
+++ b/contracts/RegistryHelper.sol
@@ -93,6 +93,8 @@ contract RegistryHelper {
             "Device wallet already exists"
         );
 
+        // Deploys device smart wallet
+        // Updates device wallet info via Registry
         address deviceWallet = address(deviceWalletFactory.createAccount(_deviceUniqueIdentifier, _deviceWalletOwnerKey, _salt));
 
         address[] memory eSIMWallets;

--- a/contracts/RegistryHelper.sol
+++ b/contracts/RegistryHelper.sol
@@ -93,7 +93,7 @@ contract RegistryHelper {
             "Device wallet already exists"
         );
 
-        address deviceWallet = deviceWalletFactory.deployDeviceWallet(_deviceUniqueIdentifier, _deviceWalletOwnerKey, _salt);
+        address deviceWallet = address(deviceWalletFactory.createAccount(_deviceUniqueIdentifier, _deviceWalletOwnerKey, _salt));
 
         address[] memory eSIMWallets;
 

--- a/contracts/RegistryHelper.sol
+++ b/contracts/RegistryHelper.sol
@@ -142,6 +142,7 @@ contract RegistryHelper {
         emit DeviceWalletInfoUpdated(_deviceWallet, _deviceUniqueIdentifier, _deviceWalletOwnerKey);
     }
 
+    /// @dev Internal function to deploy Device wallet factory during Registry initialisation
     function _deployDeviceWalletFactory(
         IEntryPoint entryPoint,
         P256Verifier _verifier,
@@ -160,6 +161,7 @@ contract RegistryHelper {
         deviceWalletFactory = DeviceWalletFactory(address(deviceWalletFactoryProxy));
     }
 
+    /// @dev Internal function to deploy eSIM wallet factory during Registry initialisation
     function _deployESIMWalletFactory(
         address _upgradeManager
     ) internal {

--- a/contracts/device-wallet/DeviceWallet.sol
+++ b/contracts/device-wallet/DeviceWallet.sol
@@ -238,17 +238,17 @@ contract DeviceWallet is Initializable, Account4337 {
         bool _hasAccessToETH
     ) public onlyRegistryOrDeviceWalletFactoryOrOwner {
         require(_deviceWalletAddress != address(this), "Cannot update to same address");
-        require(
-            registry.isESIMWalletOnStandby(_eSIMWalletAddress) == true,
-            "Must be on standby"
-        );
+        require(registry.isESIMWalletValid(_eSIMWalletAddress) == address(0), "Already has device wallet");
+        
         isValidESIMWallet[_eSIMWalletAddress] = true;
         canPullETH[_eSIMWalletAddress] = _hasAccessToETH;
 
         // Inform and update the registry about the newly added eSIM wallet to this device wallet
         registry.updateDeviceWalletAssociatedWithESIMWallet(_eSIMWalletAddress, _deviceWalletAddress);
         // Since the eSIM wallet now has a device wallet, remove it from standby
-        registry.setESIMWalletToStandby(_eSIMWalletAddress, false);
+        if(registry.isESIMWalletOnStandby(_eSIMWalletAddress)) {
+            registry.setESIMWalletToStandby(_eSIMWalletAddress, false);
+        }
 
         emit ESIMWalletAdded(_eSIMWalletAddress, _hasAccessToETH, msg.sender);
     }

--- a/contracts/device-wallet/DeviceWallet.sol
+++ b/contracts/device-wallet/DeviceWallet.sol
@@ -175,8 +175,8 @@ contract DeviceWallet is Initializable, Account4337 {
     ///      the eSIM wallet can directly request the device wallet to pay ETH for the data bundles
     /// @param _amount Amount of ETH to pull
     function payETHForDataBundles(uint256 _amount) external onlyAssociatedESIMWallets returns (uint256) {
-        require(_amount > 0, "Amount cannot be zero");
-        require(canPullETH[msg.sender] == true, "Cannot pull ETH. Access has been revoked");
+        require(_amount > 0, "_amount 0");
+        require(canPullETH[msg.sender] == true, "Access revoked");
 
         address vault = getVaultAddress();
         _transferETH(vault, _amount);
@@ -189,8 +189,8 @@ contract DeviceWallet is Initializable, Account4337 {
     /// @notice Allow the eSIM wallets associated with this device wallet to pull ETH (for data bundles)
     /// @param _amount Amount of ETH to pull
     function pullETH(uint256 _amount) external onlyAssociatedESIMWallets returns (uint256) {
-        require(_amount > 0, "Amount cannot be zero");
-        require(canPullETH[msg.sender] == true, "Cannot pull ETH. Access revoked");
+        require(_amount > 0, "_amount 0");
+        require(canPullETH[msg.sender] == true, "Access revoked");
 
         _transferETH(msg.sender, _amount);
 
@@ -207,7 +207,7 @@ contract DeviceWallet is Initializable, Account4337 {
     /// @param _eSIMWalletAddress Address of the eSIM wallet to toggle ETH access for
     /// @param _hasAccessToETH Set to true to give access, false to revoke access
     function toggleAccessToETH(address _eSIMWalletAddress, bool _hasAccessToETH) external onlySelf {
-        require(isValidESIMWallet[_eSIMWalletAddress], "Invalid eSIM wallet address");
+        require(isValidESIMWallet[_eSIMWalletAddress], "Unknown _eSIMWalletAddress");
 
         canPullETH[_eSIMWalletAddress] = _hasAccessToETH;
 
@@ -215,8 +215,8 @@ contract DeviceWallet is Initializable, Account4337 {
     }
 
     function _transferETH(address _recipient, uint256 _amount) internal virtual {
-        require(_amount <= address(this).balance, "Not enough ETH in wallet");
-        require(_recipient != address(0), "Recipient cannot be zero address");
+        require(_amount <= address(this).balance, "Not enough ETH");
+        require(_recipient != address(0), "_recipient 0");
 
         if (_amount > 0) {
             (bool success,) = _recipient.call{value: _amount}("");

--- a/contracts/device-wallet/DeviceWallet.sol
+++ b/contracts/device-wallet/DeviceWallet.sol
@@ -247,7 +247,7 @@ contract DeviceWallet is Initializable, Account4337 {
         registry.updateDeviceWalletAssociatedWithESIMWallet(_eSIMWalletAddress, _deviceWalletAddress);
         // Since the eSIM wallet now has a device wallet, remove it from standby
         if(registry.isESIMWalletOnStandby(_eSIMWalletAddress)) {
-            registry.setESIMWalletToStandby(_eSIMWalletAddress, false);
+            registry.toggleESIMWalletStandbyStatus(_eSIMWalletAddress, false);
         }
 
         emit ESIMWalletAdded(_eSIMWalletAddress, _hasAccessToETH, msg.sender);
@@ -268,7 +268,7 @@ contract DeviceWallet is Initializable, Account4337 {
 
         // Inform and update the registry about the newly added eSIM wallet to this device wallet
         registry.updateDeviceWalletAssociatedWithESIMWallet(_eSIMWalletAddress, address(0));
-        registry.setESIMWalletToStandby(_eSIMWalletAddress, true);
+        registry.toggleESIMWalletStandbyStatus(_eSIMWalletAddress, true);
 
         emit ESIMWalletRemoved(_eSIMWalletAddress, _deviceWalletAddress, msg.sender);
     }

--- a/contracts/device-wallet/DeviceWalletFactory.sol
+++ b/contracts/device-wallet/DeviceWalletFactory.sol
@@ -226,9 +226,9 @@ contract DeviceWalletFactory is Initializable, OwnableUpgradeable {
             _salt
         );
 
-        address memory wallet = registry.uniqueIdentifierToDeviceWallet(_deviceUniqueIdentifier);
+        address wallet = registry.uniqueIdentifierToDeviceWallet(_deviceUniqueIdentifier);
         if(wallet != address(0)) {
-            return wallet;
+            return DeviceWallet(payable(wallet));
         }
 
         uint256 codeSize = addr.code.length;

--- a/contracts/device-wallet/DeviceWalletFactory.sol
+++ b/contracts/device-wallet/DeviceWalletFactory.sol
@@ -192,14 +192,10 @@ contract DeviceWalletFactory is Initializable, OwnableUpgradeable {
 
         ESIMWalletFactory eSIMWalletFactory = registry.eSIMWalletFactory();
         address eSIMWalletAddress = eSIMWalletFactory.deployESIMWallet(deviceWalletAddress, _salt);
-        DeviceWallet(payable(deviceWalletAddress)).updateESIMInfo(
+        DeviceWallet(payable(deviceWalletAddress)).addESIMWallet(
             eSIMWalletAddress,
-            true,
+            deviceWalletAddress,
             true
-        );
-        DeviceWallet(payable(deviceWalletAddress)).updateDeviceWalletAssociatedWithESIMWallet(
-            eSIMWalletAddress,
-            deviceWalletAddress
         );
 
         emit DeviceWalletDeployed(deviceWalletAddress, eSIMWalletAddress, _deviceWalletOwnerKey);

--- a/contracts/device-wallet/DeviceWalletFactory.sol
+++ b/contracts/device-wallet/DeviceWalletFactory.sol
@@ -218,10 +218,6 @@ contract DeviceWalletFactory is Initializable, OwnableUpgradeable {
             bytes(_deviceUniqueIdentifier).length != 0, 
             "DeviceIdentifier cannot be empty"
         );
-        require(
-            registry.uniqueIdentifierToDeviceWallet(_deviceUniqueIdentifier) == address(0),
-            "DeviceIdentifier already in use"
-        );
 
         address addr = getAddress(
             address(registry),

--- a/contracts/device-wallet/DeviceWalletFactory.sol
+++ b/contracts/device-wallet/DeviceWalletFactory.sol
@@ -154,7 +154,7 @@ contract DeviceWalletFactory is Initializable, OwnableUpgradeable {
         string[] memory _deviceUniqueIdentifiers,
         bytes32[2][] memory _deviceWalletOwnersKey,
         uint256[] calldata _salts
-    ) public onlyAdmin returns (address[] memory) {
+    ) public payable onlyAdmin returns (address[] memory) {
         uint256 numberOfDeviceWallets = _deviceUniqueIdentifiers.length;
         require(numberOfDeviceWallets != 0, "Array cannot be empty");
         require(numberOfDeviceWallets == _deviceWalletOwnersKey.length, "Array mismatch");
@@ -181,7 +181,7 @@ contract DeviceWalletFactory is Initializable, OwnableUpgradeable {
         string memory _deviceUniqueIdentifier,
         bytes32[2] memory _deviceWalletOwnerKey,
         uint256 _salt
-    ) public onlyAdmin returns (address) {
+    ) public payable onlyAdmin returns (address) {
         address deviceWalletAddress = address(
             createAccount(
                 _deviceUniqueIdentifier,

--- a/contracts/device-wallet/DeviceWalletFactory.sol
+++ b/contracts/device-wallet/DeviceWalletFactory.sol
@@ -226,6 +226,11 @@ contract DeviceWalletFactory is Initializable, OwnableUpgradeable {
             _salt
         );
 
+        address memory wallet = registry.uniqueIdentifierToDeviceWallet(_deviceUniqueIdentifier);
+        if(wallet != address(0)) {
+            return wallet;
+        }
+
         uint256 codeSize = addr.code.length;
         if (codeSize > 0) {
             return DeviceWallet(payable(addr));


### PR DESCRIPTION
* Removed duplicate functions with similar outcomes
* `createAccount` function in the DeviceWalletFactory replaces the `deployWallet` function
* Removed `deployWallet` function from the Registry contract because of the following reasons: 
1.  Could be front-run because of no access protection
2. Similar functionality to `deployDeviceWalletAsAdmin` in DeviceWalletFactory contract
3. Registry contract is already way too big